### PR TITLE
catch JSON parse error in template

### DIFF
--- a/src/videojs-chapter-thumbnail-template.js
+++ b/src/videojs-chapter-thumbnail-template.js
@@ -10,9 +10,15 @@ const defaults = {
 };
 
 function chapterThumbnailTemplate(cue = {}, options = {}) {
-    let template = options.template || defaults.template;
+    let template = options.template || defaults.template,
+        cue_text = {};
 
-    let cue_text = JSON.parse(cue.text || '{}');
+    try {
+        cue_text = JSON.parse(cue.text);
+    } catch (e) {
+        // failed to parse JSON, fallback on raw text in title
+        cue_text = {title: cue.text, image: ''};
+    }
 
     for (let key in cue_text) {
         if (cue_text.hasOwnProperty(key)) {

--- a/test/videojs-chapter-thumbnail-template.spec.js
+++ b/test/videojs-chapter-thumbnail-template.spec.js
@@ -14,6 +14,19 @@ describe('chapter-thumbnail-template.js', function () {
         );
     });
 
+    it('should return the modified default template when receiving non JSON data.', function () {
+        expect(chapterThumbnailTemplate({
+            text: "example"
+        })).toBe(
+            `
+<div class="vjs-chapters-thumbnails-item">
+    <img class="vjs-chapters-thumbnails-item-image" src="" />
+    <span class="vjs-chapters-thumbnails-item-title">example</span>
+</div>
+`
+        );
+    });
+
     it('should return the modified default template.', function () {
         expect(chapterThumbnailTemplate({
             text: JSON.stringify({


### PR DESCRIPTION
If vtt file have malformed json or chapters are defined with text only on purpose,
don't throw error and display raw content.
