### PR TITLE
fix(subtitle) don't show subtitle text on screen

### DIFF
--- a/src/menu/chapter-thumbnail-menu-button.js
+++ b/src/menu/chapter-thumbnail-menu-button.js
@@ -132,6 +132,27 @@ class ChapterThumbnailMenuButton extends VjsMenuButton {
     for (let i = 0, length = textTrack.cues.length; i < length; i++) {
       const cue = textTrack.cues[i];
 
+      // This will be called repeatedly, so only try to set `cue.thumbnailData` if it hasn't been
+      // set yet.
+      if (textTrack.kind === 'metadata' && !cue.thumbnailData) {
+        try {
+          // Try to parse the text. This will throw if it isn't parseable, which means we don't want
+          // to change it.
+          JSON.parse(cue.text);
+
+          // Add thumbnail info to the cue. This is non-standard, but so are chapter thumbnails.
+          cue.thumbnailData = cue.text;
+
+          // Remove the text so nothing is displayed on screen when the thumbnail is active
+          cue.text = '';
+        } catch (error) {
+          // Filter out `SyntaxError`, throw on everything else.
+          if (typeof error !== SyntaxError) {
+            throw error;
+          }
+        }
+      }
+
       items.push(new MenuItem(this.player(), {
         cue,
         template,

--- a/src/videojs-chapter-thumbnail-template.js
+++ b/src/videojs-chapter-thumbnail-template.js
@@ -1,19 +1,19 @@
 const defaults = {
   template(cue = {}) {
-    let cueText;
+    let cueThumbnailData;
 
-    // NOTE: if `cue.text` isn't parseable, just send it through instead of blowing up.
+    // NOTE: if `cue.thumbnailData` isn't parseable, just send it through instead of blowing up.
     // DRAGON: this probably opens up a possible script injection
     try {
-      cueText = JSON.parse(cue.text || '{}');
+      cueThumbnailData = JSON.parse(cue.thumbnailData || '{}');
     } catch (e) {
-      cueText = cue.text;
+      cueThumbnailData = cue.thumbnailData;
     }
 
     const {
       image,
       title,
-    } = cueText;
+    } = cueThumbnailData;
 
     const template = document.createElement('div');
     template.className = 'vjs-chapters-thumbnails-item';


### PR DESCRIPTION
Right now this plugin depends on `cue.text` to get the chapter title and image. `video.js` will interpret text as something that should be displayed on the screen which is not what we want. This will refactor out how the thumbnail data is retrieved and stored so we have access to that data but set `cue.text = ''` so it won't be shown on screen.