### PR TITLE
fix(track) set the mode to disabled and default to false

### DIFF
--- a/src/videojs-chapter-thumbnail.js
+++ b/src/videojs-chapter-thumbnail.js
@@ -62,9 +62,10 @@ export default class ChapterThumbnails {
     this.player = player;
 
     this.textTrack = videojs.mergeOptions(defaults, options, {
-      default: true,
-      kind: 'metadata',
+      default: false,
       id: TRACK_ID,
+      kind: 'metadata',
+      mode: 'disabled',
     });
 
     this.template = this.textTrack.template;


### PR DESCRIPTION
This will prevent video.js or native track implementations from trying to display the track. Metadata tracks aren't supposed to be displayed anyway, but I haven't found anything in the docs that way they won't if you try to show them.