### PR TITLE
chore(webpack) only apply transform-runtime to prod build

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,9 +1,15 @@
 {
   "plugins": [
-    "transform-object-rest-spread",
-    "transform-runtime"
+    "transform-object-rest-spread"
   ],
   "presets": [
     "es2015"
-  ]
+  ],
+  "env": {
+    "production": {
+      "plugins": [
+        "transform-runtime"
+      ]
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "karma-phantomjs-launcher": "^1.0.4",
     "karma-webpack": "^1.8.0",
     "load-grunt-tasks": "^3.5.2",
+    "lodash": "^4.17.4",
     "moment": "^2.14.1",
     "node-sass": "^3.8.0",
     "null-loader": "^0.1.1",

--- a/webpack/webpack.config.production.js
+++ b/webpack/webpack.config.production.js
@@ -1,5 +1,6 @@
 const CleanWebpackPlugin = require('clean-webpack-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const merge = require('lodash/merge');
 const path = require('path');
 const webpack = require('webpack');
 const webpackConfig = require('./webpack.config');
@@ -19,6 +20,23 @@ webpackConfig.module.loaders = [{
   ),
   test: /\.scss$/,
 }];
+
+// Add `forceEnv: 'prod'` to all babel postLoaders
+webpackConfig.module.postLoaders = webpackConfig.module.postLoaders.map((loader) => {
+  if (loader.loader.indexOf('babel') !== 0) {
+    return loader;
+  }
+
+  return merge(
+    {},
+    loader,
+    {
+      query: {
+        forceEnv: 'production',
+      },
+    }
+  );
+});
 
 webpackConfig.plugins = [
   new CleanWebpackPlugin('dist', {


### PR DESCRIPTION
This will allow this package to `npm-link`'ed by not using `transform-runtime` unless we're building production.