### PR TITLE
Migrate to 6 — use newer 'registerPlugin' function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "videojs-chapter-thumbnails",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Video.js plugin for supporting chapter thumbnails",
   "main": "./dist/videojs.chapter-thumbnails.min.js",
   "style": "./dist/videojs.chapter-thumbnails.min.css",

--- a/src/videojs-chapter-thumbnail.js
+++ b/src/videojs-chapter-thumbnail.js
@@ -115,7 +115,9 @@ export default class ChapterThumbnails {
   }
 }
 
-videojs.plugin('chapter_thumbnails', function chapterThumbnails(options) {
+const registerPlugin = videojs.registerPlugin || videojs.plugin;
+
+registerPlugin('chapter_thumbnails', function chapterThumbnails(options) {
   const chapterThumbnail = new ChapterThumbnails(this, options);
 
   chapterThumbnail.addComponent();


### PR DESCRIPTION
Adjustment to plugin function as it is now deprecated in video.js 6.

More details: https://github.com/videojs/video.js/wiki/Video.js-6-Migration-Guide